### PR TITLE
Add tv webhook trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## v3.0.0 - 2022-05-28
+
+### Changed
+
+- Added tradingview alert webhooks support in https://github.com/MauricioKruijer/tandeytrader/pull/6
+
 ## v2.0.0 - 2022-05-28
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google-cloud/firestore": "^5.0.2",
         "@google-cloud/functions-framework": "^3.1.1",
+        "axios": "^0.27.2",
         "express": "^4.18.1",
         "puppeteer": "^14.1.1",
         "telegraf": "^4.8.2",
@@ -2721,8 +2722,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/at-least-node": {
       "version": "1.0.0",
@@ -2742,6 +2742,28 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/babel-jest": {
@@ -3423,7 +3445,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3750,7 +3771,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4806,6 +4826,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-each": {
       "version": "0.3.3",
@@ -12143,8 +12182,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "at-least-node": {
       "version": "1.0.0",
@@ -12156,6 +12194,27 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "babel-jest": {
       "version": "27.5.1",
@@ -12656,7 +12715,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -12905,8 +12963,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "2.0.0",
@@ -13712,6 +13769,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "for-each": {
       "version": "0.3.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tandeytrader",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tandeytrader",
-      "version": "2.0.0",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/firestore": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tandeytrader",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "license": "MIT",
   "scripts": {
     "serve:get-chart-url": "cd dist/packages/apps/get-chart-url; nodemon -w . -e js -x npx functions-framework --target=get-chart-url"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@google-cloud/firestore": "^5.0.2",
     "@google-cloud/functions-framework": "^3.1.1",
+    "axios": "^0.27.2",
     "express": "^4.18.1",
     "puppeteer": "^14.1.1",
     "telegraf": "^4.8.2",

--- a/packages/apps/dolladollabillbot/.env.example
+++ b/packages/apps/dolladollabillbot/.env.example
@@ -3,3 +3,4 @@ BOT_TOKEN=Your access token you got from @BotFather
 WEBHOOK_URL=http://localhost:8080/telegraf
 PROJECT=yourproject
 GOOGLE_APPLICATION_CREDENTIALS=/path/to/gcp_serviceaccount.json
+GET_CHART_URL_ENDPOINT=http://localhost:8081/

--- a/packages/apps/dolladollabillbot/.env.yaml.example
+++ b/packages/apps/dolladollabillbot/.env.yaml.example
@@ -1,3 +1,4 @@
 DEV: "false"
 BOT_TOKEN: "Ask the https://t.me/BotFather for a access token"
 WEBHOOK_URL: "http://localhost:8080/telegraf"
+GET_CHART_URL_ENDPOINT: "http://localhost:8081/"

--- a/packages/libs/charts/.babelrc
+++ b/packages/libs/charts/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/packages/libs/charts/.eslintrc.json
+++ b/packages/libs/charts/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/packages/libs/charts/README.md
+++ b/packages/libs/charts/README.md
@@ -1,0 +1,11 @@
+# libs-charts
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test libs-charts` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint libs-charts` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/libs/charts/README.md
+++ b/packages/libs/charts/README.md
@@ -1,11 +1,11 @@
-# libs-charts
+# charts
 
 This library was generated with [Nx](https://nx.dev).
 
 ## Running unit tests
 
-Run `nx test libs-charts` to execute the unit tests via [Jest](https://jestjs.io).
+Run `nx test charts` to execute the unit tests via [Jest](https://jestjs.io).
 
 ## Running lint
 
-Run `nx lint libs-charts` to execute the lint via [ESLint](https://eslint.org/).
+Run `nx lint charts` to execute the lint via [ESLint](https://eslint.org/).

--- a/packages/libs/charts/jest.config.ts
+++ b/packages/libs/charts/jest.config.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 export default {
-  displayName: 'libs-charts',
+  displayName: 'charts',
   preset: '../../../jest.preset.js',
   globals: {
     'ts-jest': {

--- a/packages/libs/charts/jest.config.ts
+++ b/packages/libs/charts/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'libs-charts',
+  preset: '../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../coverage/packages/libs/charts',
+};

--- a/packages/libs/charts/project.json
+++ b/packages/libs/charts/project.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "../../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "packages/libs/charts/src",
+  "projectType": "library",
+  "targets": {
+    "lint": {
+      "executor": "@nrwl/linter:eslint",
+      "outputs": ["{options.outputFile}"],
+      "options": {
+        "lintFilePatterns": ["packages/libs/charts/**/*.ts"]
+      }
+    },
+    "test": {
+      "executor": "@nrwl/jest:jest",
+      "outputs": ["coverage/packages/libs/charts"],
+      "options": {
+        "jestConfig": "packages/libs/charts/jest.config.ts",
+        "passWithNoTests": true
+      }
+    }
+  },
+  "tags": []
+}

--- a/packages/libs/charts/src/index.ts
+++ b/packages/libs/charts/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/libs-charts';
+export * from './lib/charts';

--- a/packages/libs/charts/src/index.ts
+++ b/packages/libs/charts/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/libs-charts';

--- a/packages/libs/charts/src/index.ts
+++ b/packages/libs/charts/src/index.ts
@@ -1,1 +1,3 @@
-export * from './lib/charts';
+export * from './lib/createChart'
+export * from './lib/getChartSubscribers'
+export * from './lib/charts'

--- a/packages/libs/charts/src/lib/charts.spec.ts
+++ b/packages/libs/charts/src/lib/charts.spec.ts
@@ -1,0 +1,7 @@
+import { charts } from './charts';
+
+describe('charts', () => {
+  it('should work', () => {
+    expect(charts()).toEqual('charts');
+  });
+});

--- a/packages/libs/charts/src/lib/charts.ts
+++ b/packages/libs/charts/src/lib/charts.ts
@@ -1,0 +1,3 @@
+export function charts(): string {
+  return 'charts';
+}

--- a/packages/libs/charts/src/lib/createChart.ts
+++ b/packages/libs/charts/src/lib/createChart.ts
@@ -1,0 +1,16 @@
+import { db } from './db'
+
+export const createCharts = async (chartId: string, alertType: string, description: string) => {
+  const docRef = db.collection('charts').doc(`${chartId}`);
+  const chart = await docRef.get();
+  await docRef.collection('alerts').doc(alertType).set({ description });
+  if (!chart.exists) {
+    try {
+      await docRef.set({
+        subscribers: []
+      })
+    } catch(error) {
+      console.log('error', error);
+    }
+  }
+}

--- a/packages/libs/charts/src/lib/createChart.ts
+++ b/packages/libs/charts/src/lib/createChart.ts
@@ -1,6 +1,6 @@
 import { db } from './db'
 
-export const createCharts = async (chartId: string, alertType: string, description: string) => {
+export const createChart = async (chartId: string, alertType: string, description: string) => {
   const docRef = db.collection('charts').doc(`${chartId}`);
   const chart = await docRef.get();
   await docRef.collection('alerts').doc(alertType).set({ description });

--- a/packages/libs/charts/src/lib/db.ts
+++ b/packages/libs/charts/src/lib/db.ts
@@ -1,0 +1,4 @@
+const Firestore = require('@google-cloud/firestore')
+const { PROJECT, GOOGLE_APPLICATION_CREDENTIALS } = process.env
+
+export const db = new Firestore({ projectId: PROJECT, keyFile: GOOGLE_APPLICATION_CREDENTIALS })

--- a/packages/libs/charts/src/lib/getChartSubscribers.ts
+++ b/packages/libs/charts/src/lib/getChartSubscribers.ts
@@ -1,0 +1,12 @@
+import { db } from './db'
+
+export const getChartSubscribers = async (chartId: string): Promise<string[]> => {
+  const subscribersRef = db.collection('charts').doc(`${chartId}`)
+  const subscribers = await subscribersRef.get()
+
+  if (subscribers.exists) {
+    return subscribers.data().subscribers
+  }
+
+  return []
+}

--- a/packages/libs/charts/src/lib/libs-charts.spec.ts
+++ b/packages/libs/charts/src/lib/libs-charts.spec.ts
@@ -1,7 +1,0 @@
-import { libsCharts } from './libs-charts';
-
-describe('libsCharts', () => {
-  it('should work', () => {
-    expect(libsCharts()).toEqual('libs-charts');
-  });
-});

--- a/packages/libs/charts/src/lib/libs-charts.spec.ts
+++ b/packages/libs/charts/src/lib/libs-charts.spec.ts
@@ -1,0 +1,7 @@
+import { libsCharts } from './libs-charts';
+
+describe('libsCharts', () => {
+  it('should work', () => {
+    expect(libsCharts()).toEqual('libs-charts');
+  });
+});

--- a/packages/libs/charts/src/lib/libs-charts.ts
+++ b/packages/libs/charts/src/lib/libs-charts.ts
@@ -1,0 +1,3 @@
+export function libsCharts(): string {
+  return 'libs-charts';
+}

--- a/packages/libs/charts/src/lib/libs-charts.ts
+++ b/packages/libs/charts/src/lib/libs-charts.ts
@@ -1,3 +1,0 @@
-export function libsCharts(): string {
-  return 'libs-charts';
-}

--- a/packages/libs/charts/tsconfig.json
+++ b/packages/libs/charts/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/packages/libs/charts/tsconfig.lib.json
+++ b/packages/libs/charts/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/packages/libs/charts/tsconfig.spec.json
+++ b/packages/libs/charts/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,7 +15,10 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@tandeytrader/libs/store-conversation": ["packages/libs/store-conversation/src/index.ts"]
+      "@tandeytrader/libs/charts": ["packages/libs/charts/src/index.ts"],
+      "@tandeytrader/libs/store-conversation": [
+        "packages/libs/store-conversation/src/index.ts"
+      ]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/workspace.json
+++ b/workspace.json
@@ -4,7 +4,7 @@
   "projects": {
     "dolladollabillbot": "packages/apps/dolladollabillbot",
     "get-chart-url": "packages/apps/get-chart-url",
-    "libs-charts": "packages/libs/charts",
+    "charts": "packages/libs/charts",
     "store-conversation": "packages/libs/store-conversation"
   }
 }

--- a/workspace.json
+++ b/workspace.json
@@ -2,8 +2,9 @@
   "$schema": "./node_modules/nx/schemas/workspace-schema.json",
   "version": 2,
   "projects": {
-    "get-chart-url": "packages/apps/get-chart-url",
     "dolladollabillbot": "packages/apps/dolladollabillbot",
+    "get-chart-url": "packages/apps/get-chart-url",
+    "libs-charts": "packages/libs/charts",
     "store-conversation": "packages/libs/store-conversation"
   }
 }


### PR DESCRIPTION
# v3.0.0
Added support for webhook triggers send by tradingview. You can add a webhook url when setting up alerts in TV, use this "syntax" to receive chart images from your telegram bot once an alert was send out.

## Breaking changes

Update env

#### Set up alert webhook in tradingview (example)
<img width="525" alt="image" src="https://user-images.githubusercontent.com/224625/170860454-55ec0e09-44dc-4079-85a1-f2de5c1d26e5.png">

- Add an alert
- Set up description as JSON payload
- Use structured url

### Payload

```json
{
  "description": "This field is required"
}
```

### Webhook url

The syntax is as follows:

> https :// us-central1- **YOUR_PROJECT_NAME** .cloudfunctions.net/dolladollabillbot/charts/ **CHART_ID** / **ALERT_NAME**

This set up is not strict at all, there is no proper error handling/validation at this time (yet). So make sure to have a valid chart set up hehe.

- `YOUR_PROJECT_NAME` e.g. **_mrmoneymaker_** this is your own gcp project 
- `CHART_ID` e.g. **_1TpxCs53_** you can find this ID when you create (or use an existing) chart and set sharing on
- `ALERT_NAME` e.g. **_rsi_overbought_** this must be unique to the alerts on this chart, again no checks implemented yet, so remember it 

### Getting CHART_ID

- Log in to tradingview 
- Load or create a new Chart Layout
- Click on the little arrow icon in the right corner (see image below)
- <img width="453" alt="image" src="https://user-images.githubusercontent.com/224625/170861579-509b1350-2ce7-4fb4-8413-2e672ded0d91.png">
- Enable sharing
- <img width="213" alt="image" src="https://user-images.githubusercontent.com/224625/170861610-4161e367-365c-4827-b864-aa9516e5a563.png">

Now check the URL in your browser, the last part is the `CHART_ID`. For example if you see something like https://www.tradingview.com/chart/gmeFakaOG/ then your id will be `gmeFakaOG` 👍 
